### PR TITLE
[New] Add `--ignore-pattern` flag 

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
         "allowReserved": false,
     },
     "rules": {
+        "array-bracket-newline": "off",
         "array-bracket-spacing": "off",
         "complexity": "off",
         "func-style": ["error", "declaration"],

--- a/bin/tape
+++ b/bin/tape
@@ -7,9 +7,9 @@ var objectKeys = require('object-keys');
 
 var opts = parseOpts(process.argv.slice(2), {
 	alias: { r: 'require', i: 'ignore' },
-	string: ['require', 'ignore'],
+	string: ['require', 'ignore', 'ignore-pattern'],
 	boolean: ['only'],
-	default: { r: [], i: null, only: null }
+	default: { r: [], i: null, 'ignore-pattern': null, only: null }
 });
 
 if (typeof opts.only === 'boolean') {
@@ -35,15 +35,23 @@ opts.require.forEach(function (module) {
 var resolvePath = require('path').resolve;
 var requireResolve = require.resolve;
 
-var matcher;
+var ignoreStr = '';
 if (typeof opts.ignore === 'string') {
 	var readFileSync = require('fs').readFileSync;
 	try {
-		var ignoreStr = readFileSync(resolvePath(cwd, opts.ignore || '.gitignore'), 'utf-8');
+		ignoreStr = readFileSync(resolvePath(cwd, opts.ignore || '.gitignore'), 'utf-8');
 	} catch (e) {
 		console.error(e.message);
 		process.exit(2);
 	}
+}
+
+if (typeof opts['ignore-pattern'] === 'string') {
+	ignoreStr += '\n' + opts['ignore-pattern'];
+}
+
+var matcher;
+if (ignoreStr) {
 	var ignore = require('dotignore');
 	matcher = ignore.createMatcher(ignoreStr);
 }

--- a/readme.markdown
+++ b/readme.markdown
@@ -158,13 +158,24 @@ This is used to load modules before running tests and is explained extensively i
 
 **Alias**: `-i`
 
-This flag is used when tests from certain folders and/or files are not intended to be run. It defaults to `.gitignore` file when passed with no argument.
+This flag is used when tests from certain folders and/or files are not intended to be run.
+The argument is a path to a file that contains the patterns to be ignored.
+It defaults to `.gitignore` when passed with no argument.
 
 ```sh
-tape -i .ignore **/*.js
+tape -i .ignore '**/*.js'
 ```
 
 An error is thrown if the specified file passed as argument does not exist.
+
+## --ignore-pattern
+
+Same functionality as `--ignore`, but passing the pattern directly instead of an ignore file.
+If both `--ignore` and `--ignore-pattern` are given, the `--ignore-pattern` argument is appended to the content of the ignore file.
+
+```sh
+tape --ignore-pattern 'integration_tests/**/*.js' '**/*.js'
+```
 
 ## --no-only
 This is particularly useful in a CI environment where an [only test](#testonlyname-opts-cb) is not supposed to go unnoticed.

--- a/test/ignore-pattern.js
+++ b/test/ignore-pattern.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var tap = require('tap');
+var path = require('path');
+var execFile = require('child_process').execFile;
+
+var tapeBin = path.join(process.cwd(), 'bin/tape');
+
+tap.test('should allow ignore file together with --ignore-pattern', function (tt) {
+	tt.plan(1);
+	var proc = execFile(tapeBin, ['--ignore', '.ignore', '--ignore-pattern', 'fake_other_ignored_dir', '**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
+
+	proc.on('exit', function (code) {
+		tt.equals(code, 0);
+	});
+});
+
+tap.test('should allow --ignore-pattern without ignore file', function (tt) {
+	tt.plan(1);
+	var proc = execFile(tapeBin, ['--ignore-pattern', 'fake_*', '**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
+
+	proc.on('exit', function (code) {
+		tt.equals(code, 0);
+	});
+});
+
+tap.test('should fail if not ignoring', function (tt) {
+	tt.plan(1);
+	var proc = execFile(tapeBin, ['**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
+
+	proc.on('exit', function (code) {
+		tt.equals(code, 1);
+	});
+});

--- a/test/ignore-pattern/.ignore
+++ b/test/ignore-pattern/.ignore
@@ -1,0 +1,1 @@
+fake_node_modules

--- a/test/ignore-pattern/fake_node_modules/stub1.js
+++ b/test/ignore-pattern/fake_node_modules/stub1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+	t.plan(1);
+	t.fail('Should not print');
+});

--- a/test/ignore-pattern/fake_node_modules/stub2.js
+++ b/test/ignore-pattern/fake_node_modules/stub2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+	t.fail('Should not print');
+	t.end();
+});

--- a/test/ignore-pattern/fake_other_ignored_dir/stub1.js
+++ b/test/ignore-pattern/fake_other_ignored_dir/stub1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+	t.plan(1);
+	t.fail('Should not print');
+});

--- a/test/ignore-pattern/fake_other_ignored_dir/stub2.js
+++ b/test/ignore-pattern/fake_other_ignored_dir/stub2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+	t.fail('Should not print');
+	t.end();
+});

--- a/test/ignore-pattern/test.js
+++ b/test/ignore-pattern/test.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../');
+
+tape.test(function (t) {
+	t.pass('Should print');
+	t.end();
+});

--- a/test/ignore-pattern/test/stub1.js
+++ b/test/ignore-pattern/test/stub1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+	t.plan(1);
+	t.pass('test/stub1');
+});

--- a/test/ignore-pattern/test/stub2.js
+++ b/test/ignore-pattern/test/stub2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../');
+
+tape.test(function (t) {
+	t.pass('test/stub2');
+	t.end();
+});

--- a/test/ignore-pattern/test/sub/sub.stub1.js
+++ b/test/ignore-pattern/test/sub/sub.stub1.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../../');
+
+tape.test(function (t) {
+	t.plan(1);
+	t.pass('test/sub/stub1');
+});

--- a/test/ignore-pattern/test/sub/sub.stub2.js
+++ b/test/ignore-pattern/test/sub/sub.stub2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../../../');
+
+tape.test(function (t) {
+	t.pass('test/sub/stub2');
+	t.end();
+});

--- a/test/ignore-pattern/test2.js
+++ b/test/ignore-pattern/test2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var tape = require('../../');
+
+tape.test(function (t) {
+	t.pass('Should print');
+	t.end();
+});


### PR DESCRIPTION
This PR introduces the --ignorePattern flag as a shorthand for ignoring test files.

The flag may be used together with --ignore; the input will be concatenated in that case. I figured this behavior would make the most sense, since users may want to ignore everything in .gitignore and some other files on top.

Let me know if this looks good, then I'll also add some documentation :)

Fixes https://github.com/ljharb/tape/issues/586