### PR TITLE
Fix path parsing and tests on windows

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -2,6 +2,7 @@
 
 'use strict';
 
+var path = require('path');
 var parseOpts = require('minimist');
 var objectKeys = require('object-keys');
 
@@ -66,6 +67,19 @@ var files = opts._.reduce(function (result, arg) {
 
 		if (!Array.isArray(globFiles)) {
 			throw new TypeError('unknown error: glob.sync("' + arg + '") did not return an array or throw. Please report this.');
+		}
+
+		// Workaround for glob v7 always replacing backslashes with forward slashes on windows
+		// This causes dotignore to not match the paths properly.
+		// This is fixed in newer version of glob, however we can not upgrade because it drops
+		// support for older node versions that we still want to support in tape.
+		// If glob is updated in the future this workaround can be removed, however note that
+		// the output of glob must then be sorted here because glob no longer does that.
+		// (also, backslashes and forward slashes should be ordered the same)
+		if (path.sep === '\\') {
+			globFiles = globFiles.map(function (globFile) {
+				return globFile.replace(/\//g, '\\');
+			});
 		}
 
 		return result.concat(globFiles);

--- a/lib/test.js
+++ b/lib/test.js
@@ -518,9 +518,9 @@ Test.prototype._assert = function assert(ok, opts) {
                 Last part captures file path plus line no (and optional
                 column no).
 
-                    /((?:\/|[a-zA-Z]:\\)[^:\)]+:(\d+)(?::(\d+))?)\)?/
+                    /((?:[/\\]|[a-zA-Z]:\\)[^:\)]+:(\d+)(?::(\d+))?)\)?/
             */
-			var re = /^(?:[^\s]*\s*\bat\s+)(?:(.*)\s+\()?((?:\/|[a-zA-Z]:\\)[^:)]+:(\d+)(?::(\d+))?)\)?$/;
+			var re = /^(?:[^\s]*\s*\bat\s+)(?:(.*)\s+\()?((?:[/\\]|[a-zA-Z]:\\)[^:)]+:(\d+)(?::(\d+))?)\)?$/;
 			// first tokenize the PWD, then tokenize tape
 			var lineWithTokens = $replace(
 				$replace(

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
 		"js-yaml": "^3.14.0",
 		"npm-run-posix-or-windows": "^2.0.2",
 		"npmignore": "^0.3.0",
+		"nyc": "^10.3.2",
 		"safe-publish-latest": "^2.0.0",
 		"tap": "^8.0.1",
 		"tap-parser": "^5.4.0"
@@ -80,9 +81,10 @@
 		"prelint": "npm-run-posix-or-windows eclint",
 		"lint": "eslint --ext .js,.cjs,.mjs . bin/*",
 		"pretest": "npm run lint",
-		"test": "npm run tests-only",
+		"test": "npm-run-posix-or-windows tests-only",
 		"posttest": "aud --production",
 		"tests-only": "nyc tap 'test/*.js'",
+		"tests-only:windows": "nyc node_modules\\tap\\bin\\run.js test/*.js",
 		"test:example": "find example -name '*.js' | grep -v fail | grep -v static | xargs tap"
 	},
 	"testling": {

--- a/test/ignore-pattern.js
+++ b/test/ignore-pattern.js
@@ -8,7 +8,7 @@ var tapeBin = path.join(process.cwd(), 'bin/tape');
 
 tap.test('should allow ignore file together with --ignore-pattern', function (tt) {
 	tt.plan(1);
-	var proc = execFile(tapeBin, ['--ignore', '.ignore', '--ignore-pattern', 'fake_other_ignored_dir', '**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
+	var proc = execFile(process.execPath, [tapeBin, '--ignore', '.ignore', '--ignore-pattern', 'fake_other_ignored_dir', '**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
 
 	proc.on('exit', function (code) {
 		tt.equals(code, 0);
@@ -17,7 +17,7 @@ tap.test('should allow ignore file together with --ignore-pattern', function (tt
 
 tap.test('should allow --ignore-pattern without ignore file', function (tt) {
 	tt.plan(1);
-	var proc = execFile(tapeBin, ['--ignore-pattern', 'fake_*', '**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
+	var proc = execFile(process.execPath, [tapeBin, '--ignore-pattern', 'fake_*', '**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
 
 	proc.on('exit', function (code) {
 		tt.equals(code, 0);
@@ -26,7 +26,7 @@ tap.test('should allow --ignore-pattern without ignore file', function (tt) {
 
 tap.test('should fail if not ignoring', function (tt) {
 	tt.plan(1);
-	var proc = execFile(tapeBin, ['**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
+	var proc = execFile(process.execPath, [tapeBin, '**/*.js'], { cwd: path.join(__dirname, 'ignore-pattern') });
 
 	proc.on('exit', function (code) {
 		tt.equals(code, 1);

--- a/test/ignore_from_gitignore.js
+++ b/test/ignore_from_gitignore.js
@@ -9,7 +9,7 @@ var stripFullStack = require('./common').stripFullStack;
 
 var tapeBin = path.join(process.cwd(), 'bin/tape');
 
-tap.test('Should pass with ignoring', { skip: process.platform === 'win32' }, function (tt) {
+tap.test('Should pass with ignoring', function (tt) {
 	tt.plan(2);
 
 	var tc = function (rows) {
@@ -38,14 +38,14 @@ tap.test('Should pass with ignoring', { skip: process.platform === 'win32' }, fu
 		]);
 	};
 
-	var ps = spawn(tapeBin, ['**/*.js', '-i', '.ignore'], { cwd: path.join(__dirname, 'ignore') });
+	var ps = spawn(process.execPath, [tapeBin, '**/*.js', '-i', '.ignore'], { cwd: path.join(__dirname, 'ignore') });
 	ps.stdout.pipe(concat(tc));
 	ps.on('exit', function (code) {
 		tt.equal(code, 0); // code 0
 	});
 });
 
-tap.test('Should pass', { skip: process.platform === 'win32' }, function (tt) {
+tap.test('Should pass', function (tt) {
 	tt.plan(2);
 
 	var tc = function (rows) {
@@ -95,14 +95,14 @@ tap.test('Should pass', { skip: process.platform === 'win32' }, function (tt) {
 		]);
 	};
 
-	var ps = spawn(tapeBin, ['**/*.js'], { cwd: path.join(__dirname, 'ignore') });
+	var ps = spawn(process.execPath, [tapeBin, '**/*.js'], { cwd: path.join(__dirname, 'ignore') });
 	ps.stdout.pipe(concat(tc));
 	ps.on('exit', function (code) {
 		tt.equal(code, 1);
 	});
 });
 
-tap.test('Should fail when ignore file does not exist', { skip: process.platform === 'win32' }, function (tt) {
+tap.test('Should fail when ignore file does not exist', function (tt) {
 	tt.plan(3);
 
 	var testStdout = function (rows) {
@@ -113,7 +113,7 @@ tap.test('Should fail when ignore file does not exist', { skip: process.platform
 		tt.ok((/^ENOENT[:,] no such file or directory,? (?:open )?'\$TEST\/ignore\/.gitignore'\n$/m).test(stripFullStack(rows.toString('utf8')).join('\n')));
 	};
 
-	var ps = spawn(tapeBin, ['**/*.js', '-i'], { cwd: path.join(__dirname, 'ignore') });
+	var ps = spawn(process.execPath, [tapeBin, '**/*.js', '-i'], { cwd: path.join(__dirname, 'ignore') });
 	ps.stdout.pipe(concat(testStdout));
 	ps.stderr.pipe(concat(testStderr));
 	ps.on('exit', function (code) {

--- a/test/import.js
+++ b/test/import.js
@@ -9,7 +9,7 @@ var assign = require('object.assign');
 function tape(args, options) {
 	var bin = __dirname + '/../bin/tape';
 
-	return spawn(process.argv[0], [bin].concat(args.split(' ')), assign({ cwd: __dirname }, options));
+	return spawn(process.execPath, [bin].concat(args.split(' ')), assign({ cwd: __dirname }, options));
 }
 
 tap.test('importing mjs files', function (t) {

--- a/test/require.js
+++ b/test/require.js
@@ -8,7 +8,7 @@ var stripFullStack = require('./common').stripFullStack;
 function tape(args) {
 	var bin = __dirname + '/../bin/tape';
 
-	return spawn('node', [bin].concat(args.split(' ')), { cwd: __dirname });
+	return spawn(process.execPath, [bin].concat(args.split(' ')), { cwd: __dirname });
 }
 
 tap.test('requiring a single module', function (t) {


### PR DESCRIPTION
This is a follow up of #183 which involved a similar fix for a much older version (9 years ago) of this library. I noted 4 years ago that the stack trace parsing on windows had already been fixed by someone else. 

However I just discovered that the issue has cropped up again, which this PR attempts to fix. Luckily this time the existing tests already check for this issue, however the tests must be ran on windows. This uncovered more issues because a lot of tests were broken on windows.

Some tests were attempting to spawn `bin/tape`, instead of `node bin/tape`. This does not work on my windows machine.

The failing tests uncovered that the `--ignore` and `--ignore-pattern` options do not work properly on windows. This was because the old version of glob uses forward slashes on windows, while dotignore expects backslashes.

It was not possible to run the tests using `npm test`. This was because of a bug in the old versions of `nyc`, and also because single quotes were used in the run script.

Before:

```
  303 passing (14s)
  8 pending
  64 failing
```

After:

```
  374 passing (31s)
  5 pending
```

The individual commits in this PR contain more details.